### PR TITLE
Updated with the newest version of Bevy

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,12 +13,13 @@ license-file = "LICENSE.md"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bevy = { version = "0.11.2" }
+bevy = { version = "0.15.1" }
 steam-audio = { version = "0.3" }
-glam = "0.20.5"
 rodio = "0.15.0"
 itertools = "0.11.0"
-smooth-bevy-cameras = "0.9.0" # only for the example
+
+[dev-dependencies]
+smooth-bevy-cameras = "0.13.0"
 
 [patch.crates-io]
 steam-audio = { path = "../steam-audio-rs/steam-audio" }


### PR DESCRIPTION
Updates the plugin to be up to date with Bevy 0.15.1. As well as changes the examples only dependency to be only included for the examples.